### PR TITLE
enable import streams from aeon.dj_pipeline

### DIFF
--- a/aeon/dj_pipeline/__init__.py
+++ b/aeon/dj_pipeline/__init__.py
@@ -16,6 +16,12 @@ db_prefix = dj.config["custom"].get("database.prefix", _default_database_prefix)
 repository_config = dj.config['custom'].get('repository_config',
                                             _default_repository_config)
 
+try:
+    from .utils import streams_maker
+    streams = dj.VirtualModule("streams", streams_maker.STREAMS_MODULE_NAME)
+except:
+    pass
+
 
 def get_schema_name(name):
     return db_prefix + name


### PR DESCRIPTION
Currently, streams tables are not accessible until you create a virtual module. Here I import virtual module when attempting to import streams.py via `from aeon.dj_pipeline import streams`